### PR TITLE
Flickering fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Layout
+
+| Path | Description |
+| --- | --- |
+| `crawler/` | Python crawler that scrapes the Factorio Wiki and exports `tech_tree.jsonl` |
+| `factorio-tech-tree/` | Next.js 16 app (React 19, TypeScript, Tailwind CSS v4) that renders the tech tree |
+
+## Commands
+
+### Next.js App (`cd factorio-tech-tree`)
+
+```bash
+npm run dev      # start development server
+npm run build    # production build
+npm run lint     # run ESLint
+```
+
+### Crawler (`cd crawler`)
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install requests beautifulsoup4
+
+# Run and write output to the app's data directory
+python main.py --output-jsonl ../factorio-tech-tree/data/tech_tree.jsonl
+
+# Options
+python main.py --sleep 0.5   # delay between page fetches (default: 0.1s)
+python main.py --quiet       # suppress progress logs
+```
+
+## Architecture
+
+### Data Flow
+
+1. **Crawler** (`crawler/`) scrapes the Factorio Wiki and writes `tech_tree.jsonl` — one JSON record per line, each representing a tech node with fields like `id`, `title`, `url`, `required_technologies`, `required_technologies_merged`, `image_path`, `research_type`, `research_science`.
+2. **Data files** live in `factorio-tech-tree/data/`: `tech_tree.jsonl` (tech nodes) and `tech_images/` (PNG images served as static assets from `public/`).
+3. **`load-tech-tree.ts`** (`app/lib/tech-tree/load-tech-tree.ts`) is a server-side function that reads the JSONL at build/request time, resolves dependency levels via topological sort, builds `GraphNode[]` and `GraphEdge[]`, and returns `TechTreeData`.
+4. **`page.tsx`** calls `loadTechTree()` (async Server Component), then renders the client component `TechGraph`.
+
+### Next.js App Structure
+
+- `app/page.tsx` — Server Component entry point; loads data and renders `TechGraph`
+- `app/tech-graph.tsx` — Main client component (`"use client"`); owns all interaction state (pan/zoom, selection, filters, search, navigation history)
+- `app/components/tech-graph/graph-canvas.tsx` — Renders the SVG canvas with nodes and bezier-curve edges
+- `app/components/tech-graph/graph-details.tsx` — Side panel showing selected node details and prerequisite/unlock links
+- `app/lib/tech-tree/` — Data types (`types.ts`) and JSONL loading logic (`load-tech-tree.ts`)
+- `app/lib/tech-graph/` — Pure layout/rendering utilities: `graph-layout.ts` (level-based grid layout), `constants.ts` (sizes, zoom limits, science pack name map), `types.ts`, `utils.ts`
+
+### Graph Layout
+
+Nodes are arranged in a level-based grid. Level 0 = root nodes (no prerequisites). Level is computed as `max(prerequisite levels) + 1`. Within each level, nodes are sorted alphabetically by title. Edges are rendered as cubic bezier curves between node centers.
+
+### Crawler Structure
+
+- `config.py` — Root URLs and default output path
+- `crawl.py` — BFS graph traversal from root URLs; converts edge references to internal IDs and inverts edges
+- `parsing.py` — BeautifulSoup HTML parsing for individual research pages
+- `models.py` — Data models for crawled records
+- `http_client.py` — Requests session setup
+- `io_utils.py` — JSONL write utility
+
+### Naming Conventions
+
+TypeScript files use `snake_case` for variables, functions, and props (not the typical JS `camelCase`). Component files use kebab-case filenames.

--- a/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
+++ b/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
@@ -302,24 +302,26 @@ export default function GraphCanvas({
                 }}
             >
                 <svg
-                    className={`graph-edges${highlighted_edge_ids.size === 0 ? " is-idle" : ""}`}
+                    className="graph-edges"
                     width={layout.width}
                     height={layout.height}
                     viewBox={`0 0 ${layout.width} ${layout.height}`}
                 >
                     {edges.map((edge) => {
                         const is_highlighted = highlighted_edge_ids.has(edge.id);
+                        const is_edge_idle = highlighted_edge_ids.size === 0;
+                        const is_edge_dimmed = !is_edge_idle && !is_highlighted;
                         return (
                             <g key={edge.id}>
                                 <path
-                                    className={`edge-line${is_highlighted ? " edge-highlight" : ""}`}
+                                    className={`edge-line${is_edge_idle ? " edge-idle" : ""}${is_highlighted ? " edge-highlight" : ""}${is_edge_dimmed ? " edge-dimmed" : ""}`}
                                     d={edge.path}
                                 />
                             </g>
                         );
                     })}
                 </svg>
-                <div className={`graph-nodes${related_node_ids.size > 0 ? " has-selection" : ""}`}>
+                <div className="graph-nodes">
                     {nodes.map((node) => {
                         const position = layout.positions[node.id];
                         if (!position) {
@@ -346,6 +348,7 @@ export default function GraphCanvas({
                         };
                         const is_selected = selected_node_id === node.id;
                         const is_related = related_node_ids.has(node.id);
+                        const is_selection_dimmed = related_node_ids.size > 0 && !is_related;
                         const is_filtered_out = !filter_match_ids.has(node.id);
                         const is_search_match = search_match_ids.has(node.id);
                         return (
@@ -353,7 +356,7 @@ export default function GraphCanvas({
                                 key={node.id}
                                 type="button"
                                 data-no-pan
-                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
+                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_selection_dimmed || is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
                                 style={{
                                     left: position.x,
                                     top: position.y,

--- a/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
+++ b/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
@@ -302,26 +302,24 @@ export default function GraphCanvas({
                 }}
             >
                 <svg
-                    className="graph-edges"
+                    className={`graph-edges${highlighted_edge_ids.size > 0 ? " has-selection" : ""}`}
                     width={layout.width}
                     height={layout.height}
                     viewBox={`0 0 ${layout.width} ${layout.height}`}
                 >
                     {edges.map((edge) => {
                         const is_highlighted = highlighted_edge_ids.has(edge.id);
-                        const is_edge_idle = highlighted_edge_ids.size === 0;
-                        const is_edge_dimmed = !is_edge_idle && !is_highlighted;
                         return (
                             <g key={edge.id}>
                                 <path
-                                    className={`edge-line${is_edge_idle ? " edge-idle" : ""}${is_highlighted ? " edge-highlight" : ""}${is_edge_dimmed ? " edge-dimmed" : ""}`}
+                                    className={`edge-line${is_highlighted ? " edge-highlight" : ""}`}
                                     d={edge.path}
                                 />
                             </g>
                         );
                     })}
                 </svg>
-                <div className="graph-nodes">
+                <div className={`graph-nodes${related_node_ids.size > 0 ? " has-selection" : ""}`}>
                     {nodes.map((node) => {
                         const position = layout.positions[node.id];
                         if (!position) {
@@ -348,7 +346,6 @@ export default function GraphCanvas({
                         };
                         const is_selected = selected_node_id === node.id;
                         const is_related = related_node_ids.has(node.id);
-                        const is_selection_dimmed = related_node_ids.size > 0 && !is_related;
                         const is_filtered_out = !filter_match_ids.has(node.id);
                         const is_search_match = search_match_ids.has(node.id);
                         return (
@@ -356,7 +353,7 @@ export default function GraphCanvas({
                                 key={node.id}
                                 type="button"
                                 data-no-pan
-                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_selection_dimmed || is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
+                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
                                 style={{
                                     left: position.x,
                                     top: position.y,

--- a/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
+++ b/factorio-tech-tree/app/components/tech-graph/graph-canvas.tsx
@@ -42,7 +42,6 @@ type GraphCanvasProps = {
     on_pointer_down: (event: PointerEvent<HTMLDivElement>) => void;
     on_pointer_move: (event: PointerEvent<HTMLDivElement>) => void;
     on_pointer_up: (event: PointerEvent<HTMLDivElement>) => void;
-    on_canvas_click: () => void;
     on_zoom_in: () => void;
     on_zoom_out: () => void;
     on_reset: () => void;
@@ -74,7 +73,6 @@ export default function GraphCanvas({
     on_pointer_down,
     on_pointer_move,
     on_pointer_up,
-    on_canvas_click,
     on_zoom_in,
     on_zoom_out,
     on_reset,
@@ -130,7 +128,6 @@ export default function GraphCanvas({
             onPointerMove={on_pointer_move}
             onPointerUp={on_pointer_up}
             onPointerCancel={on_pointer_up}
-            onClick={on_canvas_click}
         >
             <div className="graph-toolbar-group" data-no-pan>
                 <div
@@ -312,19 +309,17 @@ export default function GraphCanvas({
                 >
                     {edges.map((edge) => {
                         const is_highlighted = highlighted_edge_ids.has(edge.id);
-                        const is_dimmed =
-                            highlighted_edge_ids.size > 0 && !highlighted_edge_ids.has(edge.id);
                         return (
                             <g key={edge.id}>
                                 <path
-                                    className={`edge-line${is_dimmed ? " edge-dimmed" : ""}${is_highlighted ? " edge-highlight" : ""}`}
+                                    className={`edge-line${is_highlighted ? " edge-highlight" : ""}`}
                                     d={edge.path}
                                 />
                             </g>
                         );
                     })}
                 </svg>
-                <div className="graph-nodes">
+                <div className={`graph-nodes${related_node_ids.size > 0 ? " has-selection" : ""}`}>
                     {nodes.map((node) => {
                         const position = layout.positions[node.id];
                         if (!position) {
@@ -351,7 +346,6 @@ export default function GraphCanvas({
                         };
                         const is_selected = selected_node_id === node.id;
                         const is_related = related_node_ids.has(node.id);
-                        const is_dimmed = related_node_ids.size > 0 && !related_node_ids.has(node.id);
                         const is_filtered_out = !filter_match_ids.has(node.id);
                         const is_search_match = search_match_ids.has(node.id);
                         return (
@@ -359,7 +353,7 @@ export default function GraphCanvas({
                                 key={node.id}
                                 type="button"
                                 data-no-pan
-                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_dimmed || is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
+                                className={`graph-node${science_icons.length > 0 ? " has-science" : ""}${is_selected ? " is-selected" : ""}${is_related ? " is-related" : ""}${is_search_match ? " is-search-match" : ""}${is_filtered_out ? " is-dimmed" : ""}${root_set.has(node.id) ? " is-root" : ""}${node.is_infinite ? " is-infinite" : ""}`}
                                 style={{
                                     left: position.x,
                                     top: position.y,

--- a/factorio-tech-tree/app/graph.css
+++ b/factorio-tech-tree/app/graph.css
@@ -428,7 +428,7 @@
     opacity: 1;
 }
 
-.edge-line.edge-dimmed {
+.graph-edges:not(.is-idle) .edge-line:not(.edge-highlight) {
     opacity: 0.08;
 }
 
@@ -452,7 +452,7 @@
     gap: 10px;
     text-align: center;
     cursor: pointer;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease, opacity 0.15s ease;
     appearance: none;
     font-family: inherit;
 }
@@ -477,7 +477,8 @@
     box-shadow: 0 14px 26px -22px rgba(29, 111, 122, 0.45);
 }
 
-.graph-node.is-dimmed {
+.graph-node.is-dimmed,
+.graph-nodes.has-selection .graph-node:not(.is-related):not(.is-selected) {
     opacity: 0.45;
 }
 

--- a/factorio-tech-tree/app/graph.css
+++ b/factorio-tech-tree/app/graph.css
@@ -410,26 +410,20 @@
 
 .edge-line {
     fill: none;
-    stroke: var(--edge);
+    stroke: var(--edge-muted);
     stroke-width: 2.5;
-    opacity: 0.7;
-    transition: opacity 0.2s ease, stroke 0.2s ease, stroke-width 0.2s ease;
+    opacity: 0.35;
     pointer-events: none;
 }
 
-.edge-line.edge-idle {
-    stroke: var(--edge-muted);
-    opacity: 0.35;
+.graph-edges.has-selection .edge-line {
+    opacity: 0.08;
 }
 
-.edge-line.edge-highlight {
+.graph-edges.has-selection .edge-line.edge-highlight {
     stroke: var(--edge-strong);
     stroke-width: 3.4;
     opacity: 1;
-}
-
-.edge-line.edge-dimmed {
-    opacity: 0.08;
 }
 
 .graph-nodes {
@@ -452,7 +446,7 @@
     gap: 10px;
     text-align: center;
     cursor: pointer;
-    transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease, opacity 0.15s ease;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border 0.18s ease;
     appearance: none;
     font-family: inherit;
 }
@@ -477,7 +471,8 @@
     box-shadow: 0 14px 26px -22px rgba(29, 111, 122, 0.45);
 }
 
-.graph-node.is-dimmed {
+.graph-node.is-dimmed,
+.graph-nodes.has-selection .graph-node:not(.is-related):not(.is-selected) {
     opacity: 0.45;
 }
 

--- a/factorio-tech-tree/app/graph.css
+++ b/factorio-tech-tree/app/graph.css
@@ -417,7 +417,7 @@
     pointer-events: none;
 }
 
-.graph-edges.is-idle .edge-line {
+.edge-line.edge-idle {
     stroke: var(--edge-muted);
     opacity: 0.35;
 }
@@ -428,7 +428,7 @@
     opacity: 1;
 }
 
-.graph-edges:not(.is-idle) .edge-line:not(.edge-highlight) {
+.edge-line.edge-dimmed {
     opacity: 0.08;
 }
 
@@ -477,8 +477,7 @@
     box-shadow: 0 14px 26px -22px rgba(29, 111, 122, 0.45);
 }
 
-.graph-node.is-dimmed,
-.graph-nodes.has-selection .graph-node:not(.is-related):not(.is-selected) {
+.graph-node.is-dimmed {
     opacity: 0.45;
 }
 

--- a/factorio-tech-tree/app/tech-graph.tsx
+++ b/factorio-tech-tree/app/tech-graph.tsx
@@ -431,12 +431,21 @@ export default function TechGraph({ nodes, edges, root_ids }: GraphViewProps) {
             const anchor_x = clamp(event.clientX - rect.left, 0, rect.width);
             const anchor_y = clamp(event.clientY - rect.top, 0, rect.height);
             update_zoom(
-                transform.scale * zoom_factor,
+                transform_ref.current.scale * zoom_factor,
                 anchor_x,
                 anchor_y,
             );
         },
-        [transform.scale, update_zoom],
+        [update_zoom],
+    );
+
+    const on_zoom_in = useCallback(
+        () => update_zoom(transform_ref.current.scale * 1.12),
+        [update_zoom],
+    );
+    const on_zoom_out = useCallback(
+        () => update_zoom(transform_ref.current.scale * 0.88),
+        [update_zoom],
     );
     useEffect(() => {
         const container = container_ref.current;
@@ -492,16 +501,13 @@ export default function TechGraph({ nodes, edges, root_ids }: GraphViewProps) {
             return;
         }
         event.currentTarget.releasePointerCapture(event.pointerId);
+        const was_dragging = dragged_ref.current;
         pointer_ref.current = null;
+        dragged_ref.current = false;
         set_is_panning(false);
-    }, []);
-
-    const on_canvas_click = useCallback(() => {
-        if (dragged_ref.current) {
-            dragged_ref.current = false;
-            return;
+        if (!was_dragging) {
+            set_selected_node_id(null);
         }
-        set_selected_node_id(null);
     }, []);
 
     return (
@@ -530,9 +536,8 @@ export default function TechGraph({ nodes, edges, root_ids }: GraphViewProps) {
                 on_pointer_down={on_pointer_down}
                 on_pointer_move={on_pointer_move}
                 on_pointer_up={on_pointer_up}
-                on_canvas_click={on_canvas_click}
-                on_zoom_in={() => update_zoom(transform.scale * 1.12)}
-                on_zoom_out={() => update_zoom(transform.scale * 0.88)}
+                on_zoom_in={on_zoom_in}
+                on_zoom_out={on_zoom_out}
                 on_reset={fit_to_view}
                 on_select_node={select_node}
                 on_focus_node={focus_node}


### PR DESCRIPTION
Fixed flickering pheomenon when selecting or unselecting a node.

Root cause was the overloading of the render of the DOM due to too many CSS fade-in / fade-out transitions at once, with nearly 300 such transitions per click.

Therefore, the CSS animations have been reduced, and the flickering pheonomenon has been solved.